### PR TITLE
Fix AppVeyor Python 3.4 64-bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,6 +64,10 @@ install:
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
Re-render using `conda-smithy` built with this commit ( https://github.com/conda-forge/conda-smithy/commit/41e300e6a44be315e3070bf744f2c120ee5d1e8f ). This has no effect on any of the passing builds. It only changes Python 3.4 64-bit on Windows, which failed previously and thus did not upload anything. As a result, the build number will not be changed.