### PR TITLE
Bump build number to include post-link/unlink scripts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 80c325aa4db1cf3bf5c4287898ebab98
 
 build:
-    number: 0
+    number: 1
     script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Related https://github.com/conda-forge/widgetsnbextension-feedstock/pull/6.

Just bumps the build number so we can get a new release with these `post-link` and `post-unlink` scripts.