### PR TITLE
squelch link script output

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 96b4adc12e70de9c54b5eb103e1167c8
 
 build:
-    number: 1
+    number: 2
     script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,1 +1,1 @@
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable widgetsnbextension --py --sys-prefix && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable widgetsnbextension --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" enable widgetsnbextension --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" enable widgetsnbextension --py --sys-prefix > /dev/null 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,1 +1,1 @@
-"%PREFIX%\Scripts\jupyter-nbextension.exe" disable widgetsnbextension --py --sys-prefix && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" disable widgetsnbextension --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" disable widgetsnbextension --py --sys-prefix
+"${PREFIX}/bin/jupyter-nbextension" disable widgetsnbextension --py --sys-prefix > /dev/null 2>&1


### PR DESCRIPTION
Nobody likes the output from the post-link scripts from `jupyter nbextension enable`. This redirects any such output.

I'll be doing these for the other extensions as well :)
