### PR TITLE
Disable echo in [un]link batch scripts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 0aa4e152c9ba2d704389dc2453f448c7
 
 build:
-    number: 2
+    number: 3
     script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,1 +1,3 @@
+@echo off
+
 "%PREFIX%\Scripts\jupyter-nbextension.exe" enable widgetsnbextension --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,1 +1,3 @@
+@echo off
+
 "%PREFIX%\Scripts\jupyter-nbextension.exe" disable widgetsnbextension --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1


### PR DESCRIPTION
We've discovered that there is some noise from the commands run in the batch files due to these [un]link batch scripts. It was found through [discussion]( https://github.com/conda-forge/ipyparallel-feedstock/pull/6#issuecomment-234967309 ) that this change would solve that issue.